### PR TITLE
feat: implement --suffix option for prefix/suffix positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ For people who always say "oh I forgot to prefix the commit message!"
 
 The hook extracts the issue number from your branch name and prepends it to your commit message.
 
-| Branch Name | Commit Message | Result |
-|-------------|----------------|--------|
-| `feat/#111` | `Add new feature` | `[#111] Add new feature` |
-| `feature/ABC-123-impl` | `Add feature` | `[ABC-123] Add feature` |
-| `fix/#111-hello-branch` | `Fix bug` | `[#111] Fix bug` |
-| `chore/PROJ-456-cleanup` | `Cleanup` | `[PROJ-456] Cleanup` |
+| Branch Name | Commit Message | Result (default) | Result (--suffix=true) |
+|-------------|----------------|------------------|------------------------|
+| `feat/#111` | `Add new feature` | `[#111] Add new feature` | `Add new feature [#111]` |
+| `feature/ABC-123-impl` | `Add feature` | `[ABC-123] Add feature` | `Add feature [ABC-123]` |
+| `fix/#111-hello-branch` | `Fix bug` | `[#111] Fix bug` | `Fix bug [#111]` |
+| `chore/PROJ-456-cleanup` | `Cleanup` | `[PROJ-456] Cleanup` | `Cleanup [PROJ-456]` |
 
 ## Quick Start
 
@@ -58,7 +58,7 @@ pre-commit install --hook-type prepare-commit-msg
 
 ## Configuration
 
-You can customize the template and regex pattern:
+You can customize the template, regex pattern, and position:
 
 ```yaml
 repos:
@@ -69,6 +69,7 @@ repos:
         args:
           - --template=[{}]      # default: [{}]
           - --regex=#\d{1,5}     # default: #\d{1,5}
+          - --suffix=true        # default: false
 ```
 
 ### Options
@@ -77,6 +78,7 @@ repos:
 |--------|---------|-------------|
 | `--template` | `[{}]` | Template for the prefix. `{}` is replaced with the issue number. |
 | `--regex` | `#\d{1,5}` | Regex pattern to extract issue number from branch name. |
+| `--suffix` | `false` | If `true`, adds issue number as suffix instead of prefix. |
 
 ### Examples
 
@@ -109,6 +111,17 @@ args:
 ```
 
 This will create prefix `(#123)` instead of `[#123]`.
+
+**Issue number as suffix:**
+
+```yaml
+args:
+  - --template=[{}]
+  - --regex=#\d{1,5}
+  - --suffix=true
+```
+
+This will add the issue number at the end: `Add new feature [#123]`.
 
 ## Development
 

--- a/commit_issue_prefix/main.py
+++ b/commit_issue_prefix/main.py
@@ -66,7 +66,7 @@ def update_commit_message(filepath: Path, prefix: str, suffix: bool = False) -> 
         # Add as suffix: "message [#123]"
         lines = content.split("\n", maxsplit=1)
         first_line = lines[0].rstrip()
-        new_content = f"{first_line} {prefix}"
+        new_content = f"{first_line} {prefix}" if first_line else prefix
         if len(lines) > 1:
             # Preserve the newline and any content after it (even if empty)
             new_content += "\n" + lines[1]

--- a/commit_issue_prefix/main.py
+++ b/commit_issue_prefix/main.py
@@ -66,10 +66,10 @@ def update_commit_message(filepath: Path, prefix: str, suffix: bool = False) -> 
         # Add as suffix: "message [#123]"
         lines = content.split("\n", maxsplit=1)
         first_line = lines[0].rstrip()
-        rest = lines[1] if len(lines) > 1 else ""
         new_content = f"{first_line} {prefix}"
-        if rest:
-            new_content += "\n" + rest
+        if len(lines) > 1:
+            # Preserve the newline and any content after it (even if empty)
+            new_content += "\n" + lines[1]
         filepath.write_text(new_content, encoding="utf-8")
     else:
         # Add as prefix: "[#123] message"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -128,3 +128,13 @@ class TestUpdateCommitMessage:
 
         assert result is True
         assert msg_file.read_text() == "Fix bug [#456]\n"
+
+    def test_empty_message_with_suffix(self, tmp_path: Path) -> None:
+        """Test with empty commit message in suffix mode."""
+        msg_file = tmp_path / "COMMIT_EDITMSG"
+        msg_file.write_text("")
+
+        result = update_commit_message(msg_file, "[#123]", suffix=True)
+
+        assert result is True
+        assert msg_file.read_text() == "[#123]"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -78,3 +78,43 @@ class TestUpdateCommitMessage:
 
         assert result is True
         assert msg_file.read_text() == "[#123] "
+
+    def test_add_suffix(self, tmp_path: Path) -> None:
+        """Test adding suffix to commit message."""
+        msg_file = tmp_path / "COMMIT_EDITMSG"
+        msg_file.write_text("Add new feature\n\nSome description")
+
+        result = update_commit_message(msg_file, "[#111]", suffix=True)
+
+        assert result is True
+        assert msg_file.read_text() == "Add new feature [#111]\n\nSome description"
+
+    def test_add_suffix_single_line(self, tmp_path: Path) -> None:
+        """Test adding suffix to single line commit message."""
+        msg_file = tmp_path / "COMMIT_EDITMSG"
+        msg_file.write_text("Fix bug")
+
+        result = update_commit_message(msg_file, "[#456]", suffix=True)
+
+        assert result is True
+        assert msg_file.read_text() == "Fix bug [#456]"
+
+    def test_skip_existing_suffix(self, tmp_path: Path) -> None:
+        """Test skipping if suffix already exists."""
+        msg_file = tmp_path / "COMMIT_EDITMSG"
+        msg_file.write_text("Add new feature [#111]\n\nSome description")
+
+        result = update_commit_message(msg_file, "[#111]", suffix=True)
+
+        assert result is False
+        assert msg_file.read_text() == "Add new feature [#111]\n\nSome description"
+
+    def test_suffix_with_trailing_whitespace(self, tmp_path: Path) -> None:
+        """Test suffix handling with trailing whitespace in first line."""
+        msg_file = tmp_path / "COMMIT_EDITMSG"
+        msg_file.write_text("Add feature   \n\nDescription")
+
+        result = update_commit_message(msg_file, "[#789]", suffix=True)
+
+        assert result is True
+        assert msg_file.read_text() == "Add feature [#789]\n\nDescription"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -118,3 +118,13 @@ class TestUpdateCommitMessage:
 
         assert result is True
         assert msg_file.read_text() == "Add feature [#789]\n\nDescription"
+
+    def test_add_suffix_single_line_with_trailing_newline(self, tmp_path: Path) -> None:
+        """Test adding suffix to single line with trailing newline."""
+        msg_file = tmp_path / "COMMIT_EDITMSG"
+        msg_file.write_text("Fix bug\n")
+
+        result = update_commit_message(msg_file, "[#456]", suffix=True)
+
+        assert result is True
+        assert msg_file.read_text() == "Fix bug [#456]\n"


### PR DESCRIPTION
## Summary

This PR implements the `--suffix` option that allows users to add the issue number as a suffix instead of a prefix to commit messages.

### Changes
- Added `--suffix` CLI argument to `main.py` (default: `false`)
- Updated `update_commit_message` function to support suffix mode
- Added comprehensive test cases for suffix functionality
- Updated README.md with suffix option documentation and examples

### Behavior

**With `--suffix=false` (default):**
```
[#111] Add new feature
```

**With `--suffix=true`:**
```
Add new feature [#111]
```

## Test Plan

- [x] Added unit tests for suffix functionality
- [x] Added test for single line commit messages with suffix
- [x] Added test for skipping existing suffix
- [x] Added test for handling trailing whitespace

Closes #3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a --suffix option to append the issue tag to the end of commit messages, with docs and tests.
> 
> - **CLI**:
>   - Add `--suffix` boolean flag in `commit_issue_prefix/main.py` to control prefix vs. suffix placement (default: `false`).
> - **Core Logic**:
>   - Update `update_commit_message(...)` to support suffix mode, preserving body/description lines and skipping when already present.
> - **Tests**:
>   - Add suffix-related tests in `tests/test_main.py` (single line, multi-line, existing suffix, trailing whitespace).
> - **Docs**:
>   - Update `README.md` with new examples/table, configuration `args` including `--suffix`, options description, and usage examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12a24d67f5820e7723d54a256c3b5cdb5ce4376f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->